### PR TITLE
Add species as a possible spell target

### DIFF
--- a/data/mods/Aftershock/maps/furniture_and_terrain/terrain_spaceship.json
+++ b/data/mods/Aftershock/maps/furniture_and_terrain/terrain_spaceship.json
@@ -189,7 +189,7 @@
           "condition": { "u_query": "Do you want to overload the ship's drive?", "default": true },
           "effect": [
             { "u_message": "You hear a high pitched whine start and increase in volume.", "popup": true },
-            { "u_cast_spell": "gunship_drive_overload" }
+            { "u_cast_spell": { "id": "gunship_drive_overload" } }
           ]
         }
       ]

--- a/data/mods/Aftershock/maps/mapgen/map_palletes.json
+++ b/data/mods/Aftershock/maps/mapgen/map_palletes.json
@@ -61,13 +61,13 @@
   {
     "type": "palette",
     "id": "mx_gunship_palette",
+    "//": "more terrain TBD",
     "terrain": {
       "|": "t_afs_gun_ship_hull_wall",
       "/": "t_afs_gun_ship_locker_wall",
       "I": "t_afs_gun_ship_hull_hatch_c",
-      "O": "t_afs_gun_ship_hull_hatch_o",
-      "+": "t_afs_gun_ship_engine",
-      "//": "TBD"
-    }
+      "O": "t_afs_gun_ship_hull_hatch_o"
+    },
+    "furniture": { "+": "t_afs_gun_ship_engine" }
   }
 ]

--- a/src/magic.cpp
+++ b/src/magic.cpp
@@ -38,6 +38,7 @@
 #include "messages.h"
 #include "mongroup.h"
 #include "monster.h"
+#include "monstergenerator.h"
 #include "mtype.h"
 #include "mutation.h"
 #include "npc.h"
@@ -286,7 +287,7 @@ void spell_type::load( const JsonObject &jo, const std::string & )
     optional( jo, was_loaded, "targeted_monster_ids", targeted_monster_ids,
               targeted_monster_ids_reader );
 
-    const auto targeted_monster_species_reader = string_id_reader<::species_id> {};
+    const auto targeted_monster_species_reader = string_id_reader<::species_type> {};
     optional( jo, was_loaded, "targeted_monster_species", targeted_monster_species,
               targeted_monster_species_reader );
 
@@ -1291,7 +1292,7 @@ bool spell::is_valid_target( const Creature &caster, const tripoint &p ) const
                            is_valid_target( spell_target::ally ) &&
                            p != caster.pos() );
         valid = valid || ( is_valid_target( spell_target::self ) && p == caster.pos() );
-        valid = valid && target_by_monster_id( p );
+        valid = valid && ( target_by_monster_id( p ) || target_by_species_id( p ) );
     } else {
         valid = is_valid_target( spell_target::ground );
     }
@@ -1307,6 +1308,23 @@ bool spell::target_by_monster_id( const tripoint &p ) const
     if( monster *const target = get_creature_tracker().creature_at<monster>( p ) ) {
         if( type->targeted_monster_ids.find( target->type->id ) != type->targeted_monster_ids.end() ) {
             valid = true;
+        }
+    }
+    return valid;
+}
+
+bool spell::target_by_species_id( const tripoint &p ) const
+{
+    if( type->targeted_monster_species.empty() ) {
+        return true;
+    }
+    bool valid = false;
+    if( monster *const target = get_creature_tracker().creature_at<monster>( p ) ) {
+        for( const species_id &spc : target->type->species ) {
+            if( type->targeted_monster_species.find( spc ) != type->targeted_monster_species.end() ) {
+                valid = true;
+                break;
+            }
         }
     }
     return valid;
@@ -1441,18 +1459,26 @@ std::string spell::enumerate_targets() const
 
 std::string spell::list_targeted_monster_names() const
 {
-    if( type->targeted_monster_ids.empty() ) {
-        return "";
-    }
     std::vector<std::string> all_valid_monster_names;
     for( const mtype_id &mon_id : type->targeted_monster_ids ) {
         all_valid_monster_names.emplace_back( mon_id->nname() );
     }
+    if( !type->targeted_monster_species.empty() ) {
+        for( const mtype &mon : MonsterGenerator::generator().get_all_mtypes() ) {
+            for( const species_id &spc : mon.species ) {
+                if( type->targeted_monster_species.find( spc ) != type->targeted_monster_species.end() ) {
+                    all_valid_monster_names.emplace_back( mon.nname() );
+                }
+            }
+        }
+    }
+    if( all_valid_monster_names.empty() ) {
+        return "";
+    }
     //remove repeat names
     all_valid_monster_names.erase( std::unique( all_valid_monster_names.begin(),
                                    all_valid_monster_names.end() ), all_valid_monster_names.end() );
-    std::string ret = enumerate_as_string( all_valid_monster_names );
-    return ret;
+    return enumerate_as_string( all_valid_monster_names );
 }
 
 damage_type spell::dmg_type() const

--- a/src/magic.h
+++ b/src/magic.h
@@ -590,6 +590,7 @@ class spell
         bool is_valid_target( const Creature &caster, const tripoint &p ) const;
         bool is_valid_target( spell_target t ) const;
         bool target_by_monster_id( const tripoint &p ) const;
+        bool target_by_species_id( const tripoint &p ) const;
 
         // picks a random valid tripoint from @area
         cata::optional<tripoint> random_valid_target( const Creature &caster,


### PR DESCRIPTION
This is just a fix to get species targets working for spells. The main change is adding `spell::target_by_species_id` and using it to check valid targets in `spell::is_valid_target`.

Not super thoroughly tested, but the game compiles and runs (but I'm 95% sure this will work just fine)

Side note: I removed the empty map_extras.json because it was causing the CI tests to fail, but you can add it again if you have any content for it

Also included: miscellaneous JSON fixes